### PR TITLE
Fix: backport the fix to reflect ifcheckd attribute of node that joined cluster

### DIFF
--- a/attrd/commands.c
+++ b/attrd/commands.c
@@ -393,7 +393,7 @@ attrd_client_refresh(void)
     }
 
     crm_info("Updating all attributes");
-    write_attributes(TRUE, FALSE);
+    write_attributes(TRUE);
 }
 
 /*!
@@ -893,7 +893,7 @@ attrd_peer_update(crm_node_t *peer, xmlNode *xml, const char *host, bool filter)
         crm_trace("We know %s's node id now: %s",
                   known_peer->uname, known_peer->uuid);
         if (election_state(writer) == election_won) {
-            write_attributes(FALSE, TRUE);
+            write_attributes(FALSE);
             return;
         }
     }
@@ -921,8 +921,6 @@ write_or_elect_attribute(attribute_t *a)
 gboolean
 attrd_election_cb(gpointer user_data)
 {
-    crm_trace("Election complete");
-
     free(peer_writer);
     peer_writer = strdup(attrd_cluster->uname);
 
@@ -930,7 +928,7 @@ attrd_election_cb(gpointer user_data)
     attrd_peer_sync(NULL, NULL);
 
     /* Update the CIB after an election */
-    write_attributes(TRUE, FALSE);
+    write_attributes(TRUE);
     return FALSE;
 }
 
@@ -1012,15 +1010,16 @@ attrd_cib_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
 }
 
 void
-write_attributes(bool all, bool peer_discovered)
+write_attributes(bool all)
 {
     GHashTableIter iter;
     attribute_t *a = NULL;
 
+    crm_debug("Writing out %s attributes", all? "all" : "changed");
     g_hash_table_iter_init(&iter, attributes);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & a)) {
-        if (peer_discovered && a->unknown_peer_uuids) {
-            /* a new peer uuid has been discovered, try writing this attribute again. */
+        if (!all && a->unknown_peer_uuids) {
+            // Try writing this attribute again, in case peer ID was learned
             a->changed = TRUE;
         }
 

--- a/attrd/internal.h
+++ b/attrd/internal.h
@@ -22,12 +22,11 @@ cib_t *the_cib;
 crm_cluster_t *attrd_cluster;
 GHashTable *attributes;
 election_t *writer;
-int attrd_error;
 
 #define attrd_send_ack(client, id, flags) \
     crm_ipcs_send_ack((client), (id), (flags), "ack", __FUNCTION__, __LINE__)
 
-void write_attributes(bool all, bool peer_discovered);
+void write_attributes(bool all);
 void attrd_peer_message(crm_node_t *client, xmlNode *msg);
 void attrd_client_peer_remove(const char *client_name, xmlNode *xml);
 void attrd_client_clear_failure(xmlNode *xml);

--- a/attrd/main.c
+++ b/attrd/main.c
@@ -44,7 +44,7 @@
 cib_t *the_cib = NULL;
 crm_cluster_t *attrd_cluster = NULL;
 election_t *writer = NULL;
-int attrd_error = pcmk_ok;
+static int attrd_exit_status = pcmk_ok;
 
 static void
 attrd_cpg_dispatch(cpg_handle_t handle,
@@ -84,7 +84,7 @@ attrd_cpg_destroy(gpointer unused)
 
     } else {
         crm_crit("Lost connection to Corosync service!");
-        attrd_error = ECONNRESET;
+        attrd_exit_status = ECONNRESET;
         attrd_shutdown(0);
     }
 }
@@ -94,7 +94,7 @@ attrd_cib_replaced_cb(const char *event, xmlNode * msg)
 {
     crm_notice("Updating all attributes after %s event", event);
     if(election_state(writer) == election_won) {
-        write_attributes(TRUE, FALSE);
+        write_attributes(TRUE);
     }
 }
 
@@ -111,22 +111,65 @@ attrd_cib_destroy_cb(gpointer user_data)
     } else {
         /* eventually this should trigger a reconnect, not a shutdown */
         crm_err("Lost connection to CIB service!");
-        attrd_error = ECONNRESET;
+        attrd_exit_status = ECONNRESET;
         attrd_shutdown(0);
     }
 
     return;
 }
 
-static cib_t *
+static void
+attrd_erase_cb(xmlNode *msg, int call_id, int rc, xmlNode *output,
+               void *user_data)
+{
+    do_crm_log_unlikely((rc? LOG_NOTICE : LOG_DEBUG),
+                        "Cleared transient attributes: %s "
+                        CRM_XS " xpath=%s rc=%d",
+                        pcmk_strerror(rc), (char *) user_data, rc);
+}
+
+#define XPATH_TRANSIENT "//node_state[@uname='%s']/" XML_TAG_TRANSIENT_NODEATTRS
+
+/*!
+ * \internal
+ * \brief Wipe all transient attributes for this node from the CIB
+ *
+ * Clear any previous transient node attributes from the CIB. This is
+ * normally done by the DC's crmd when this node leaves the cluster, but
+ * this handles the case where the node restarted so quickly that the
+ * cluster layer didn't notice.
+ *
+ * \todo If attrd respawns after crashing (see PCMK_respawned), ideally we'd
+ *       skip this and sync our attributes from the writer. However, currently
+ *       we reject any values for us that the writer has, in
+ *       attrd_peer_update().
+ */
+static void
+attrd_erase_attrs()
+{
+    int call_id;
+    char *xpath = crm_strdup_printf(XPATH_TRANSIENT, attrd_cluster->uname);
+
+    crm_info("Clearing transient attributes from CIB " CRM_XS " xpath=%s",
+             xpath);
+
+    call_id = the_cib->cmds->delete(the_cib, xpath, NULL,
+                                    cib_quorum_override | cib_xpath);
+    the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE, xpath,
+                                          "attrd_erase_cb", attrd_erase_cb,
+                                          free);
+}
+
+static int
 attrd_cib_connect(int max_retry)
 {
-    int rc = -ENOTCONN;
     static int attempts = 0;
-    cib_t *connection = cib_new();
 
-    if(connection == NULL) {
-        return NULL;
+    int rc = -ENOTCONN;
+
+    the_cib = cib_new();
+    if (the_cib == NULL) {
+        return DAEMON_RESPAWN_STOP;
     }
 
     do {
@@ -136,7 +179,7 @@ attrd_cib_connect(int max_retry)
 
         attempts++;
         crm_debug("CIB signon attempt %d", attempts);
-        rc = connection->cmds->signon(connection, T_ATTRD, cib_command);
+        rc = the_cib->cmds->signon(the_cib, T_ATTRD, cib_command);
 
     } while(rc != pcmk_ok && attempts < max_retry);
 
@@ -145,26 +188,30 @@ attrd_cib_connect(int max_retry)
         goto cleanup;
     }
 
-    crm_info("Connected to the CIB after %d attempts", attempts);
+    crm_debug("Connected to the CIB after %d attempts", attempts);
 
-    rc = connection->cmds->set_connection_dnotify(connection, attrd_cib_destroy_cb);
+    rc = the_cib->cmds->set_connection_dnotify(the_cib, attrd_cib_destroy_cb);
     if (rc != pcmk_ok) {
         crm_err("Could not set disconnection callback");
         goto cleanup;
     }
 
-    rc = connection->cmds->add_notify_callback(connection, T_CIB_REPLACE_NOTIFY, attrd_cib_replaced_cb);
+    rc = the_cib->cmds->add_notify_callback(the_cib, T_CIB_REPLACE_NOTIFY, attrd_cib_replaced_cb);
     if(rc != pcmk_ok) {
         crm_err("Could not set CIB notification callback");
         goto cleanup;
     }
 
-    return connection;
+    // We have no attribute values in memory, wipe the CIB to match
+    attrd_erase_attrs();
+
+    return pcmk_ok;
 
   cleanup:
-    connection->cmds->signoff(connection);
-    cib_delete(connection);
-    return NULL;
+    the_cib->cmds->signoff(the_cib);
+    cib_delete(the_cib);
+    the_cib = NULL;
+    return DAEMON_RESPAWN_STOP;
 }
 
 static int32_t
@@ -232,6 +279,24 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
     return 0;
 }
 
+static int
+attrd_cluster_connect()
+{
+    attrd_cluster = calloc(1, sizeof(crm_cluster_t));
+
+    attrd_cluster->destroy = attrd_cpg_destroy;
+    attrd_cluster->cpg.cpg_deliver_fn = attrd_cpg_dispatch;
+    attrd_cluster->cpg.cpg_confchg_fn = pcmk_cpg_membership;
+
+    crm_set_status_callback(&attrd_peer_change_cb);
+
+    if (crm_cluster_connect(attrd_cluster) == FALSE) {
+        crm_err("Cluster connection failed");
+        return DAEMON_RESPAWN_STOP;
+    }
+    return pcmk_ok;
+}
+
 /* *INDENT-OFF* */
 static struct crm_option long_options[] = {
     /* Top-level Options */
@@ -245,7 +310,6 @@ static struct crm_option long_options[] = {
 int
 main(int argc, char **argv)
 {
-    int rc = pcmk_ok;
     int flag = 0;
     int index = 0;
     int argerr = 0;
@@ -288,32 +352,22 @@ main(int argc, char **argv)
     crm_info("Starting up");
     attributes = g_hash_table_new_full(crm_str_hash, g_str_equal, NULL, free_attribute);
 
-    attrd_cluster = malloc(sizeof(crm_cluster_t));
-
-    attrd_cluster->destroy = attrd_cpg_destroy;
-    attrd_cluster->cpg.cpg_deliver_fn = attrd_cpg_dispatch;
-    attrd_cluster->cpg.cpg_confchg_fn = pcmk_cpg_membership;
-
-    crm_set_status_callback(&attrd_peer_change_cb);
-
-    if (crm_cluster_connect(attrd_cluster) == FALSE) {
-        crm_err("Cluster connection failed");
-        rc = DAEMON_RESPAWN_STOP;
+    attrd_exit_status = attrd_cluster_connect();
+    if (attrd_exit_status != pcmk_ok) {
         goto done;
     }
     crm_info("Cluster connection active");
+
+    attrd_exit_status = attrd_cib_connect(10);
+    if (attrd_exit_status != pcmk_ok) {
+        goto done;
+    }
+    crm_info("CIB connection active");
 
     writer = election_init(T_ATTRD, attrd_cluster->uname, 120000, attrd_election_cb);
     attrd_init_ipc(&ipcs, attrd_ipc_dispatch);
     crm_info("Accepting attribute updates");
 
-    the_cib = attrd_cib_connect(10);
-    if (the_cib == NULL) {
-        rc = DAEMON_RESPAWN_STOP;
-        goto done;
-    }
-
-    crm_info("CIB connection active");
     attrd_run_mainloop();
 
   done:
@@ -331,8 +385,5 @@ main(int argc, char **argv)
         cib_delete(the_cib);
     }
 
-    if(attrd_error) {
-        return crm_exit(attrd_error);
-    }
-    return crm_exit(rc);
+    return crm_exit(attrd_exit_status);
 }

--- a/crmd/join_client.c
+++ b/crmd/join_client.c
@@ -286,12 +286,12 @@ do_cl_join_finalize_respond(long long action,
                   join_id, fsa_our_dc);
 
         /*
-         * If this is the node's first join since the crmd started on it, clear
-         * any previous transient node attributes, to handle the case where
-         * the node restarted so quickly that the cluster layer didn't notice.
+         * If this is the node's first join since the crmd started on it,
+         * set its initial state (standby or member) according to the user's
+         * preference.
          *
-         * Do not remove the resources though, they'll be cleaned up in
-         * do_dc_join_ack(). Removing them here creates a race condition if the
+         * We do not clear the LRM history here. Even if the DC failed to do it
+         * when we last left, removing them here creates a race condition if the
          * crmd is being recovered. Instead of a list of active resources from
          * the lrmd, we may end up with a blank status section. If we are _NOT_
          * lucky, we will probe for the "wrong" instance of anonymous clones and
@@ -299,10 +299,6 @@ do_cl_join_finalize_respond(long long action,
          */
         if (first_join && is_not_set(fsa_input_register, R_SHUTDOWN)) {
             first_join = FALSE;
-            erase_status_tag(fsa_our_uname, XML_TAG_TRANSIENT_NODEATTRS, 0);
-            update_attrd(fsa_our_uname, "terminate", NULL, NULL, FALSE);
-            update_attrd(fsa_our_uname, XML_CIB_ATTR_SHUTDOWN, "0", NULL, FALSE);
-
             if (start_state) {
                 set_join_state(start_state);
             }


### PR DESCRIPTION
backport commit:
  https://github.com/ClusterLabs/pacemaker/commit/743097b Clear transient attributes at attrd start-up rather than crmd first join

  Between Pacemaker-1.1.17 and https://github.com/ClusterLabs/pacemaker/commit/743097b, changes have been made to attrd/main.c so applied the changes manually.